### PR TITLE
 Merge " [FAB-13843] Fix cclifecycle test flake" into release-1.4

### DIFF
--- a/docs/source/couchdb_as_state_database.rst
+++ b/docs/source/couchdb_as_state_database.rst
@@ -73,25 +73,34 @@ CouchDB pagination
 
 Fabric supports paging of query results for rich queries and range based queries.
 APIs supporting pagination allow the use of page size and bookmarks to be used for
-both range and rich queries.
+both range and rich queries. To support efficient pagination, the Fabric
+pagination APIs must be used. Specifically, the CouchDB ``limit`` keyword will
+not be honored in CouchDB queries since Fabric itself manages the pagination of
+query results and implicitly sets the pageSize limit that is passed to CouchDB.
 
-If a pagesize is specified using the paginated query APIs (``GetStateByRangeWithPagination``,
+If a pageSize is specified using the paginated query APIs (``GetStateByRangeWithPagination()``,
 ``GetStateByPartialCompositeKeyWithPagination()``, and ``GetQueryResultWithPagination()``),
-a set of results will be returned along with a bookmark. The bookmark can be used
-with a follow on query to receive the next "page" of results.
+a set of results (bound by the pageSize) will be returned to the chaincode along with
+a bookmark. The bookmark can be returned from chaincode to invoking clients,
+which can use the bookmark in a follow on query to receive the next "page" of results.
 
-All chaincode queries are bound by ``totalQueryLimit`` (default 100000)
-from ``core.yaml``. This is the maximum number of results that chaincode
-will iterate through and return to the client, in order to avoid accidental
-or malicious long-running queries.
+The pagination APIs are for use in read-only transactions only, the query results
+are intended to support client paging requirements. For transactions
+that need to read and write, use the non-paginated chaincode query APIs. Within
+chaincode you can iterate through result sets to your desired depth.
 
-An example using pagination is included in the :doc:`couchdb_tutorial` tutorial.
+Regardless of whether the pagination APIs are utilized, all chaincode queries are
+bound by ``totalQueryLimit`` (default 100000) from ``core.yaml``. This is the maximum
+number of results that chaincode will iterate through and return to the client,
+in order to avoid accidental or malicious long-running queries.
 
 .. note:: Regardless of whether chaincode uses paginated queries or not, the peer will
           query CouchDB in batches based on ``internalQueryLimit`` (default 1000)
           from ``core.yaml``. This behavior ensures reasonably sized result sets are
-          passed between the peer and CouchDB, and is transparent to chaincode and
-          requires no additional configuration.
+          passed between the peer and CouchDB when executing chaincode, and is
+          transparent to chaincode and the calling client.
+
+An example using pagination is included in the :doc:`couchdb_tutorial` tutorial.
 
 CouchDB indexes
 ~~~~~~~~~~~~~~~

--- a/docs/source/idemix.rst
+++ b/docs/source/idemix.rst
@@ -152,8 +152,11 @@ If Fabric CA is the credential issuer:
   create an 'admin' identity, register the identity with the ``role`` attribute
   and a value of ``2``.
 
-For an example of using the `cid` library to retrieve these attributes, see
-`this java SDK example <https://github.com/hyperledger/fabric-sdk-java/blob/master/src/test/fixture/sdkintegration/gocc/sampleIdemix/src/github.com/example_cc/example_cc.go>`_.
+
+For an example of setting an affiliation in the Java SDK see this `sample <https://github.com/hyperledger/fabric-sdk-java/blob/release-1.4/src/test/java/org/hyperledger/fabric/sdkintegration/End2endIdemixIT.java#L121>`_.
+
+For an example of using the CID library in go chaincode to retrieve attributes,
+see this `go chaincode <https://github.com/hyperledger/fabric-sdk-java/blob/release-1.4/src/test/fixture/sdkintegration/gocc/sampleIdemix/src/github.com/example_cc/example_cc.go#L88>`_.
 
 Current limitations
 -------------------


### PR DESCRIPTION
FAB-13471 Introduced a UT that does several (3) background listener updates.
The test only waits for the listener updates to fire, but there is a log invocation
that happens immediately afte the listener fires.

The next test that runs, overwrites the logger's reference and thus a data race
occurs (the previous test's spawned goroutine reads the logger's reference to write
the log, while the next test replaces the logger reference.

Fixed it by making the test wait until the log of the first test, logs
the last message that is logged during the listener dispatch - 3 times.

Ideally we'd have a logger instance for the production struct as a field,
but this solution is far easier and has no production code change, so its
surface area is smaller.

Change-Id: Ia7ef144ae8574783b2b7a4925f47b51e966f8942
Signed-off-by: yacovm <yacovm@il.ibm.com>